### PR TITLE
Fix disposal of scanner view

### DIFF
--- a/www/BarcodeScannerView.js
+++ b/www/BarcodeScannerView.js
@@ -27,6 +27,7 @@ class BarcodeScannerView extends tabris.Widget {
 
   _dispose() {
     this.stop();
+    super._dispose();
   }
 
   start(formats = []) {


### PR DESCRIPTION
_dispose() was overwritten without calling the parent function.

Fix #2 
