### PR TITLE
Add TypeScript type definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "tabris-plugin-barcode-scanner",
   "version": "1.0.1",
   "description": "A barcode scanner widget for Tabris.js",
+  "types": "./types/index.d.ts",
   "cordova": {
     "id": "tabris-plugin-barcode-scanner",
     "platforms": [

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,65 @@
+import { EventObject, PropertyChangedEvent, Widget, WidgetEvents, WidgetProperties } from 'tabris';
+/// <reference path='../../node_modules/tabris/tabris.d.ts' />
+
+interface BarcodeScannerViewProperties {
+  camera?: 'front' | 'back';
+  scaleMode?: 'fit' | 'fill';
+  readonly running?: boolean;
+}
+
+interface BarcodeScannerViewEvents extends WidgetEvents {
+  detect?: (event: DetectEvent) => void;
+  error?: (event: ErrorEvent) => void;
+  runningChanged?: (event: RunningChangedEvent) => void;
+}
+
+declare global {
+  namespace esbarcodescanner {
+    interface BarcodeScannerView extends BarcodeScannerViewProperties {}
+    class BarcodeScannerView extends Widget {
+      public tsProperties: WidgetProperties & BarcodeScannerViewProperties;
+      public jsxProperties: JSX.WidgetProperties & BarcodeScannerViewProperties & {
+        onDetect?: (event: DetectEvent) => void,
+        onError?: (event: ErrorEvent) => void,
+        onRunningChanged?: (event: RunningChangedEvent) => void
+      };
+      constructor(properties: WidgetProperties & BarcodeScannerViewProperties);
+      start(formats: BarcodeScannerFormat[]): void;
+      stop(): void;
+      on(type: string, listener: (event: any) => void, context?: object): this;
+      on(listeners: BarcodeScannerViewEvents): this;
+      off(type: string, listener: (event: any) => void, context?: object): this;
+      off(listeners: BarcodeScannerViewEvents): this;
+      once(type: string, listener: (event: any) => void, context?: object): this;
+      once(listeners: BarcodeScannerViewEvents): this;
+    }
+  }
+}
+
+type BarcodeScannerFormat =
+  'upcA' |
+  'upcE' |
+  'code39' |
+  'code39Mod43' |
+  'code93' |
+  'code128' |
+  'ean8' |
+  'ean13' |
+  'pdf417' |
+  'qr' |
+  'aztec' |
+  'interleaved2of5' |
+  'itf' |
+  'dataMatrix' |
+  'codabar';
+
+interface ErrorEvent extends EventObject<esbarcodescanner.BarcodeScannerView> {
+  error: string;
+}
+
+interface DetectEvent extends EventObject<esbarcodescanner.BarcodeScannerView> {
+  format: BarcodeScannerFormat;
+  data: string;
+}
+
+type RunningChangedEvent = PropertyChangedEvent<esbarcodescanner.BarcodeScannerView, boolean>;


### PR DESCRIPTION
Enable type-safe usage in TypeScript projects.

The TypeScript definitions require a Tabris.js module to be installed as
a sibling of this dependency, which must be the case for Tabris.js app
projects.

Fix #3

Change-Id: Ib0f375c336d205fa2f648261f244e1cf2d22205f