### PR TITLE
Fix <edit-config /> usage and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,14 +59,12 @@ To fetch the latest development version use the GitHub URL:
 
 ### iOS
 
-The plugin requires key-value entry. `NSCameraUsageDescription` with description has to be added to the `Info.plist` file of your app to work correctly. Please include it in your `project.xml` file. 
+The plugin requires key-value entry. `NSCameraUsageDescription` with description has to be added to the `Info.plist` file of your app to work correctly. Please include this configuration in your `config.xml` file. 
 
 ```xml
-<platform name="ios">
-  <edit-config target="NSCameraUsageDescription" file="*-Info.plist" mode="merge">
-    <string>Your custom description.</string>
-  </edit-config>
-</platform>
+<edit-config target="NSCameraUsageDescription" file="*-Info.plist" mode="merge">
+  <string>Your custom description.</string>
+</edit-config>
 ```
 
 ## API

--- a/example/cordova/config.xml
+++ b/example/cordova/config.xml
@@ -12,10 +12,8 @@
 
   <plugin name="tabris-plugin-barcode-scanner" spec="../" />
 
-  <platform name="ios">
-    <edit-config target="NSCameraUsageDescription" file="*-Info.plist" mode="merge">
-      <string>Barcode scanner requires camera to be able to scan barcodes.</string>
-    </edit-config>
-  </platform>
+  <edit-config target="NSCameraUsageDescription" file="*-Info.plist" mode="merge">
+    <string>Barcode scanner requires camera to be able to scan barcodes.</string>
+  </edit-config>
 
 </widget>


### PR DESCRIPTION
Don't recommend letting `<edit-config />` be a `<platform />` child, 
this is not supported by Cordova CLI 6.5.0 used by Tabris.js CLI.

The build will continue if the file attribute of `<edit-config />` does 
not match, so this configuration can be safely reused for all platforms.
