### PR TITLE
Migrate to Tabris 3.9

### DIFF
--- a/project/android/barcode-scanner/build.gradle
+++ b/project/android/barcode-scanner/build.gradle
@@ -3,18 +3,18 @@ apply plugin: 'kotlin-android'
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
-    implementation 'com.eclipsesource.tabris.android:tabris:3.6.0'
+    implementation 'com.eclipsesource.tabris.android:tabris:3.9.0'
     implementation "androidx.appcompat:appcompat:$supportLibraryVersion"
     implementation "com.google.android.gms:play-services-vision:$playServicesVersion"
 }
 
 android {
 
-    compileSdkVersion 28
+    compileSdkVersion 32
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 28
+        targetSdkVersion 32
     }
 
     lintOptions {

--- a/src/android/com/eclipsesource/tabris/barcodescanner/BarcodeScannerView.kt
+++ b/src/android/com/eclipsesource/tabris/barcodescanner/BarcodeScannerView.kt
@@ -78,16 +78,16 @@ class BarcodeScannerView(private val scope: ActivityScope)
   init {
     addView(cameraView)
     cameraView.holder.addCallback(object : SurfaceHolder.Callback {
-      override fun surfaceCreated(holder: SurfaceHolder?) {
+      override fun surfaceCreated(holder: SurfaceHolder) {
         surfaceAvailable = true
         startWhenReady()
       }
 
-      override fun surfaceDestroyed(holder: SurfaceHolder?) {
+      override fun surfaceDestroyed(holder: SurfaceHolder) {
         surfaceAvailable = false
       }
 
-      override fun surfaceChanged(holder: SurfaceHolder?, format: Int, width: Int, height: Int) {
+      override fun surfaceChanged(holder: SurfaceHolder, format: Int, width: Int, height: Int) {
       }
     })
     addOnLayoutChangeListener { _, left, top, right, bottom, oldLeft, oldTop, oldRight, oldBottom ->


### PR DESCRIPTION
The change migrates the project to be compatible with the Tabris 3.9 version and updates compile and target SDK versions.