### PR TITLE
[iOS] Support camera frame duration

### DIFF
--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -1,0 +1,24 @@
+{
+  "name": "example",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "tabris": "nightly"
+      }
+    },
+    "node_modules/tabris": {
+      "version": "3.9.0-dev.20240801",
+      "resolved": "https://registry.npmjs.org/tabris/-/tabris-3.9.0-dev.20240801.tgz",
+      "integrity": "sha512-u6Tjxs2HV5l2MUzZwEiJPipG/2V9Attujf52sR9zESTYKiGMhF78gIoLF8O83Q3SbDtgI4oVtPLQTInhKFLVOw=="
+    }
+  },
+  "dependencies": {
+    "tabris": {
+      "version": "3.9.0-dev.20240801",
+      "resolved": "https://registry.npmjs.org/tabris/-/tabris-3.9.0-dev.20240801.tgz",
+      "integrity": "sha512-u6Tjxs2HV5l2MUzZwEiJPipG/2V9Attujf52sR9zESTYKiGMhF78gIoLF8O83Q3SbDtgI4oVtPLQTInhKFLVOw=="
+    }
+  }
+}

--- a/example/src/app.js
+++ b/example/src/app.js
@@ -1,29 +1,25 @@
-const { Composite, TextView, Picker, Button, contentView } = require('tabris');
+const { Composite, TextView, Picker, Button, contentView, device } = require('tabris');
 
+const is_iOS = device.platform === 'iOS';
 const BARCODES = ['all formats', 'upcA', 'upcE', 'code39', 'code39Mod43', 'code93', 'code128',
   'ean8', 'ean13', 'pdf417', 'qr', 'aztec', 'interleaved2of5', 'itf', 'dataMatrix', 'codabar'];
 const SCALE_MODES = ['fit', 'fill'];
 
-let scanner = new esbarcodescanner.BarcodeScannerView({
+const scanner = new esbarcodescanner.BarcodeScannerView({
   left: 0, top: 0, right: 0, bottom: '#controls',
-}).on('detect', (event) => {
-  barcodeTextView.text = `<b>${event.format}</b><br /><i>${event.data}</i>`;
-  barcodeTextView.background = '#66BB6A';
-  setTimeout(() => barcodeTextView.background = 'white', 500);
-}).on('activeChanged', ({ value: active }) => {
-  scannerButton.text = (active ? 'Stop' : 'Start') + ' barcode scanner';
-  formatPicker.enabled = !active;
-}).on('error', (event) => console.log(event.error))
+}).on('detect', handleDetection)
+  .on('activeChanged', handleActiveChange)
+  .on('error', handleError)
   .appendTo(contentView);
 
-let controls = new Composite({
+const controls = new Composite({
   id: 'controls',
   left: 0, right: 0, bottom: 0,
   elevation: 2,
   background: '#FAFAFA',
 }).appendTo(contentView);
 
-let barcodeTextView = new TextView({
+const barcodeTextView = new TextView({
   left: 0, top: 0, right: 0, height: 48,
   text: '<i>Scanning for barcode...</i>',
   markupEnabled: true,
@@ -33,37 +29,106 @@ let barcodeTextView = new TextView({
 }).appendTo(controls);
 
 new Composite({
-  top: "prev()", left: 0, right: 0, height: 1,
+  top: 'prev()', left: 0, right: 0, height: 1,
   background: '#00000022',
 }).appendTo(controls);
 
-let formatPicker = new Picker({
+const formatPicker = new Picker({
   left: 16, top: 'prev() 16', right: 16,
   itemCount: BARCODES.length,
   selectionIndex: 0,
-  itemText: (index) => BARCODES[index],
+  itemText: index => BARCODES[index],
 }).appendTo(controls);
 
 new Picker({
   left: 16, top: 'prev() 16', right: 16,
   itemCount: SCALE_MODES.length,
   selectionIndex: 0,
-  itemText: (index) => SCALE_MODES[index],
-}).onSelect((event) => scanner.scaleMode = SCALE_MODES[event.index])
+  itemText: index => SCALE_MODES[index],
+}).onSelect(event => scanner.scaleMode = SCALE_MODES[event.index])
   .appendTo(controls);
 
-let scannerButton = new Button({
+if (is_iOS) {
+  console.log(`Combinations available on this device, with camera: ${scanner.camera}.\n${JSON.stringify(tabris.contentView.children()[0].frameDurationsForResolutions,null,2)}`);
+  initIOSPickers();
+}
+
+const scannerButton = new Button({
   left: 16, top: 'prev() 16', right: 16, bottom: 24
-}).onSelect(() => toggleScanner())
+}).onSelect(toggleScanner)
   .appendTo(controls);
+
+function handleDetection(event) {
+  barcodeTextView.text = `<b>${event.format}</b><br /><i>${event.data}</i>`;
+  barcodeTextView.background = '#66BB6A';
+  setTimeout(() => barcodeTextView.background = 'white', 500);
+}
+
+function handleActiveChange({ value: active }) {
+  scannerButton.text = (active ? 'Stop' : 'Start') + ' barcode scanner';
+  formatPicker.enabled = !active;
+}
+
+function handleError(event) {
+  console.log(event.error);
+}
 
 function toggleScanner() {
   if (scanner.active) {
     scanner.stop();
   } else {
-    let index = Math.max(0, formatPicker.selectionIndex);
+    const index = Math.max(0, formatPicker.selectionIndex);
     scanner.start(index !== 0 ? [BARCODES[index]] : []);
+    if (is_iOS) reloadIOSPickers();
   }
+}
+
+function initIOSPickers() {
+  const resolutionPicker = new Picker({
+    id: 'resolutionPicker',
+    left: 16, top: 'prev() 16', right: 16,
+    itemCount: scanner.availableResolutions.length,
+    selectionIndex: 0,
+    itemText: index => JSON.stringify(scanner.availableResolutions[index]),
+  }).onSelect(handleResolutionSelect)
+    .appendTo(controls);
+
+  const frameDurationPicker = new Picker({
+    id: 'frameDurationPicker',
+    left: 16, top: 'prev() 16', right: 16,
+    itemCount: scanner.availableFrameDurations.length,
+    selectionIndex: 0,
+    itemText: index => JSON.stringify(scanner.availableFrameDurations[index]),
+  }).onSelect(handleFrameDurationSelect)
+    .appendTo(controls);
+}
+
+function handleResolutionSelect(e) {
+  scanner.resolution = scanner.availableResolutions[e.index];
+  reloadIOSPickers();
+}
+
+function handleFrameDurationSelect(e) {
+  scanner.frameDuration = scanner.availableFrameDurations[e.index];
+  reloadIOSPickers();
+}
+
+function reloadIOSPickers() {
+  const resolution = scanner.resolution;
+  const frameDuration = scanner.frameDuration;
+
+  const resolutionPicker = $(Picker).first('#resolutionPicker');
+  const frameDurationPicker = $(Picker).first('#frameDurationPicker');
+
+  const availableFrameDurations = scanner.availableFrameDurations;
+  frameDurationPicker.itemCount = availableFrameDurations.length;
+
+  const resolutionIndex = scanner.availableResolutions.findIndex(res => res.width === resolution.width && res.height === resolution.height);
+  const frameDurationIndex = availableFrameDurations.findIndex(rate => rate === frameDuration);
+
+  resolutionPicker.selectionIndex = resolutionIndex;
+  frameDurationPicker.itemText = index => JSON.stringify(availableFrameDurations[index]);
+  frameDurationPicker.selectionIndex = frameDurationIndex;
 }
 
 toggleScanner();

--- a/plugin.xml
+++ b/plugin.xml
@@ -60,6 +60,10 @@
     <source-file src="src/ios/ESBarcodeScanner.m" />
     <header-file src="src/ios/ESScannerView.h" />
     <source-file src="src/ios/ESScannerView.m" />
+    <header-file src="src/ios/BSCameraResolution.h" />
+    <source-file src="src/ios/BSCameraResolution.m" />
+    <header-file src="src/ios/AVCaptureDeviceFormat+TabrisBarcodeScanner.h" />
+    <source-file src="src/ios/AVCaptureDeviceFormat+TabrisBarcodeScanner.m" />
   </platform>
 
 </plugin>

--- a/src/ios/AVCaptureDeviceFormat+TabrisBarcodeScanner.h
+++ b/src/ios/AVCaptureDeviceFormat+TabrisBarcodeScanner.h
@@ -1,0 +1,19 @@
+//
+//  AVCaptureDeviceFormat+TabrisBarcodeScanner.h
+//  Barcode scanner example for Tabris.js
+//
+//  Created by Karol Szafranski on 09.08.24.
+//
+
+#import <AVFoundation/AVFoundation.h>
+#import "BSCameraResolution.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface AVCaptureDeviceFormat (TabrisBarcodeScanner)
+
+@property (nonatomic, readonly) BSTabrisCameraResolution* tabrisResolution;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/src/ios/AVCaptureDeviceFormat+TabrisBarcodeScanner.m
+++ b/src/ios/AVCaptureDeviceFormat+TabrisBarcodeScanner.m
@@ -1,0 +1,20 @@
+//
+//  AVCaptureDeviceFormat+TabrisBarcodeScanner.m
+//  Barcode scanner example for Tabris.js
+//
+//  Created by Karol Szafranski on 09.08.24.
+//
+
+#import "AVCaptureDeviceFormat+TabrisBarcodeScanner.h"
+
+@implementation AVCaptureDeviceFormat (TabrisBarcodeScanner)
+
+- (BSTabrisCameraResolution*)tabrisResolution {
+    CMVideoDimensions dimensions = CMVideoFormatDescriptionGetDimensions(self.formatDescription);
+    return @{
+        BSCameraResolutionWidthKey: @(dimensions.width),
+        BSCameraResolutionHeightKey: @(dimensions.height)
+    };
+}
+
+@end

--- a/src/ios/BSCameraResolution.h
+++ b/src/ios/BSCameraResolution.h
@@ -1,0 +1,33 @@
+//
+//  BSCameraResolution.h
+//  Barcode scanner example for Tabris.js
+//
+//  Created by Karol Szafranski on 07.08.24.
+//
+
+#import <Foundation/Foundation.h>
+#import <AVFoundation/AVFoundation.h>
+
+#define BSCameraResolutionWidthKey @"width"
+#define BSCameraResolutionHeightKey @"height"
+
+typedef NSDictionary<NSString*,NSNumber*> BSTabrisCameraResolution;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface BSCameraResolution : NSObject<NSCopying>
+
+@property (assign, nonatomic, readonly) NSUInteger width;
+@property (assign, nonatomic, readonly) NSUInteger height;
+@property (assign, nonatomic, readonly) NSUInteger numberOfPixels;
+
++ (instancetype)withWidth:(NSUInteger)width andHeight:(NSUInteger)height;
++ (instancetype)withCaptureDeviceFormat:(AVCaptureDeviceFormat*)captureDeviceFormat;
++ (instancetype)withDictionary:(BSTabrisCameraResolution*)dictionary;
+
+- (BSTabrisCameraResolution *)toTabrisDictionary;
+- (NSComparisonResult)compare:(BSCameraResolution *)otherCameraResolution;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/src/ios/BSCameraResolution.m
+++ b/src/ios/BSCameraResolution.m
@@ -1,0 +1,104 @@
+//
+//  BSCameraResolution.m
+//  Barcode scanner example for Tabris.js
+//
+//  Created by Karol Szafranski on 07.08.24.
+//
+
+#import "BSCameraResolution.h"
+#import <Tabris/Tabris.h>
+
+@interface BSCameraResolution()
+
+@property (assign, nonatomic, readwrite) NSUInteger width;
+@property (assign, nonatomic, readwrite) NSUInteger height;
+@property (assign, nonatomic, readwrite) NSUInteger numberOfPixels;
+
+@end
+
+@implementation BSCameraResolution
+
++ (instancetype)withWidth:(NSUInteger)width andHeight:(NSUInteger)height {
+    BSCameraResolution* cameraResolution = [BSCameraResolution new];
+    cameraResolution.width = width;
+    cameraResolution.height = height;
+    return cameraResolution;
+}
+
++ (instancetype)withVideoDimensions:(CMVideoDimensions)videoDimensions {
+    return [BSCameraResolution withWidth:videoDimensions.width
+                             andHeight:videoDimensions.height];
+}
+
++ (instancetype)withDictionary:(NSDictionary*)dictionary {
+    NSNumber* width = [dictionary objectForKey:BSCameraResolutionWidthKey];
+    width = [width objectAsInstanceOf:[NSNumber class]];
+
+    NSNumber* height = [dictionary objectForKey:BSCameraResolutionHeightKey];
+    height = [height objectAsInstanceOf:[NSNumber class]];
+
+    if (width && height) {
+        return [BSCameraResolution withWidth:width.unsignedIntegerValue
+                                 andHeight:height.unsignedIntegerValue];
+    }
+    return nil;
+}
+
++ (instancetype)withCaptureDeviceFormat:(AVCaptureDeviceFormat*)captureDeviceFormat {
+    BSCameraResolution* cameraResolution;
+    CMFormatDescriptionRef formatDescription = captureDeviceFormat.formatDescription;
+    CMMediaType mediaType = CMFormatDescriptionGetMediaType(formatDescription);
+    if (mediaType == kCMMediaType_Video) {
+        CMVideoFormatDescriptionRef videoFormatDescription = formatDescription;
+        CMVideoDimensions videoDimensions = CMVideoFormatDescriptionGetDimensions(videoFormatDescription);
+        cameraResolution = [BSCameraResolution withVideoDimensions:videoDimensions];
+    }
+    return cameraResolution;
+}
+
+- (NSComparisonResult)compare:(BSCameraResolution *)otherBSCameraResolution {
+    if (self.numberOfPixels > otherBSCameraResolution.numberOfPixels) {
+        return NSOrderedDescending;
+    }
+    else if(self.numberOfPixels < otherBSCameraResolution.numberOfPixels) {
+        return NSOrderedAscending;
+    }
+    return NSOrderedSame;
+}
+
+- (NSUInteger)numberOfPixels {
+    if(_numberOfPixels == 0) {
+        _numberOfPixels = self.width * self.height;
+    }
+    return _numberOfPixels;
+}
+
+- (NSUInteger)hash {
+    return @(self.numberOfPixels).hash;
+}
+
+- (BOOL)isEqual:(id)object {
+    BSCameraResolution* otherBSCameraResolution = [NSObject object:object asInstanceOf:[BSCameraResolution class]];
+    BOOL isEqual = self.hash == otherBSCameraResolution.hash;
+    return isEqual;
+}
+
+- (NSString *)description {
+    return [NSString stringWithFormat:@"<%@ %p width=%lui height=%lui numberOfPixels=%lui>", NSStringFromClass(self.class), self, (unsigned long)self.width, (unsigned long)self.height, (unsigned long)self.numberOfPixels];
+}
+
+- (BSTabrisCameraResolution *)toTabrisDictionary {
+    return [NSDictionary dictionaryWithObjectsAndKeys:
+            @(self.width), BSCameraResolutionWidthKey,
+            @(self.height), BSCameraResolutionHeightKey,
+            nil];
+}
+
+-(id)copyWithZone:(NSZone *)zone {
+    BSCameraResolution* cameraResolution = [[BSCameraResolution allocWithZone:zone] init];
+    cameraResolution.width = self.width;
+    cameraResolution.height = self.height;
+    return cameraResolution;
+}
+
+@end

--- a/src/ios/ESBarcodeScanner.m
+++ b/src/ios/ESBarcodeScanner.m
@@ -3,14 +3,22 @@
 //  tabris-plugin-barcode-scanner
 //
 //  Created by Patryk Mól on 06.02.2018.
+//  Updated by Karol Szafrański on 09.08.2024.
 //  Copyright (c) 2018 EclipseSource. All rights reserved.
 //
 
+#import <Tabris/Tabris.h>
 #import "ESBarcodeScanner.h"
 #import "ESScannerView.h"
-#import <Tabris/Tabris.h>
+#import "BSCameraResolution.h"
+#import "AVCaptureDeviceFormat+TabrisBarcodeScanner.h"
+
+#define ESBarcodeScannerExceptionName @"ESBarcodeScannerException"
+
+typedef NSMutableDictionary<BSTabrisCameraResolution*, NSArray<NSNumber *>*> BSTabrisFrameDurationsForResolutions;
 
 @interface ESBarcodeScanner () <AVCaptureMetadataOutputObjectsDelegate>
+
 @property (strong, nonatomic) ESScannerView *scanner;
 @property (strong, nonatomic) AVCaptureSession *session;
 @property (strong, nonatomic) AVCaptureDevice *device;
@@ -20,32 +28,31 @@
 @property (strong, nonatomic) NSString *lastFormat;
 @property (assign, nonatomic) NSTimeInterval lastSent;
 @property (strong, nonatomic) CodeDispatcher *backgroundCodeDispatcher;
+
+@property (nonatomic, strong, readonly) BSTabrisCameraResolution *resolution;
+@property (nonatomic, strong, readonly) NSArray<BSTabrisCameraResolution *> *availableResolutions;
+@property (nonatomic, strong, readonly) NSNumber *frameDuration;
+@property (nonatomic, strong, readonly) NSArray<NSNumber *> *availableFrameDurations;
+@property (nonatomic, strong, readonly) BSTabrisFrameDurationsForResolutions *frameDurationsForResolutions;
+
 @end
 
-@implementation ESBarcodeScanner
+@implementation ESBarcodeScanner {
+    BSTabrisCameraResolution *_resolution;
+    NSNumber *_frameDuration;
+}
 
 - (instancetype)initWithObjectId:(NSString *)objectId properties:(NSDictionary *)properties inContext:(id<TabrisContext>)context {
     self = [super initWithObjectId:objectId properties:properties inContext:context];
     if (self) {
         dispatch_queue_t queue = dispatch_queue_create("ESBarcodeScanner_queue", DISPATCH_QUEUE_SERIAL);
-        self.backgroundCodeDispatcher = [[CodeDispatcher alloc] initWithQueue:queue
-                                                                  synchronous:NO];
+        self.backgroundCodeDispatcher = [[CodeDispatcher alloc] initWithQueue:queue synchronous:NO];
         self.scanner = [ESScannerView new];
         [self registerSelector:@selector(start:) forCall:@"start"];
         [self registerSelector:@selector(stop) forCall:@"stop"];
         [self defineWidgetView:self.scanner];
-        NSString *camera = [properties objectForKey:@"camera"];
-        if (camera) {
-            self.camera = camera;
-        } else {
-            self.camera = @"back";
-        }
-        NSString *scaleMode = [properties objectForKey:@"scaleMode"];
-        if (scaleMode) {
-            self.scaleMode = scaleMode;
-        } else {
-            self.scaleMode = @"fit";
-        }
+        self.camera = properties[@"camera"] ?: @"back";
+        self.scaleMode = properties[@"scaleMode"] ?: @"fit";
 
         [[NSNotificationCenter defaultCenter] addObserver:self
                                                  selector:@selector(captureSessionRuntimeErrorNotification:)
@@ -63,10 +70,9 @@
     return @"com.eclipsesource.barcodescanner.BarcodeScannerView";
 }
 
-+ (NSMutableSet *)clientObjectProperties {
++ (NSMutableSet *)remoteObjectProperties {
     NSMutableSet *set = [super remoteObjectProperties];
-    [set addObject:@"camera"];
-    [set addObject:@"scaleMode"];
+    [set addObjectsFromArray:@[@"camera", @"scaleMode", @"resolution", @"availableResolutions", @"frameDuration", @"availableFrameDurations", @"frameDurationsForResolutions"]];
     return set;
 }
 
@@ -81,45 +87,28 @@
 
 - (void)start:(NSDictionary *)properties {
     AVAuthorizationStatus status = [AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeVideo];
-    if (status == AVAuthorizationStatusAuthorized) {
-        if (!self.session) {
-            [self initializeSession];
-        }
-        if (self.session) {
-            [self setFormats:[properties objectForKey:@"formats"]];
-            [self.scanner addSession:self.session];
-            [self.backgroundCodeDispatcher dispatch:^{
-                [self.session startRunning];
-            }];
-        }
-    } else if (status == AVAuthorizationStatusDenied || status == AVAuthorizationStatusRestricted) {
-        NSString *description = (status == AVAuthorizationStatusDenied) ? @"Camera permission not granted" : @"Camera access restricted";
-        [self sendError:description];
-    } else {
-        __weak ESBarcodeScanner *weakSelf = self;
-        [AVCaptureDevice requestAccessForMediaType:AVMediaTypeVideo completionHandler:^(BOOL granted) {
-            __strong ESBarcodeScanner *strongSelf = weakSelf;
-            if (granted) {
-                dispatch_async(dispatch_get_main_queue(), ^{
-                    [strongSelf start:properties];
-                });
-            } else {
-                [strongSelf sendError:@"Camera permission not granted"];
-            }
-        }];
+    switch (status) {
+        case AVAuthorizationStatusAuthorized:
+            [self setupAndStartSessionWithProperties:properties];
+            break;
+        case AVAuthorizationStatusDenied:
+        case AVAuthorizationStatusRestricted:
+            [self sendError:(status == AVAuthorizationStatusDenied) ? @"Camera permission not granted" : @"Camera access restricted"];
+            break;
+        case AVAuthorizationStatusNotDetermined:
+            [self requestCameraAccessThenStartSessionWithProperties:properties];
+            break;
     }
 }
 
 - (void)stop {
-    [self.backgroundCodeDispatcher dispatch:^{
-        [self.session stopRunning];
-    }];
+    [self.backgroundCodeDispatcher dispatch:^{ [self.session stopRunning]; }];
 }
 
 - (void)initializeSession {
     self.session = [[AVCaptureSession alloc] init];
     self.device = [self getCaptureDevice];
-    NSError *error = nil;
+    NSError *error;
     self.input = [AVCaptureDeviceInput deviceInputWithDevice:self.device error:&error];
     if (self.input) {
         [self.session addInput:self.input];
@@ -127,65 +116,47 @@
         [self sendError:@"Could not initialize camera"];
         return;
     }
+
     self.output = [[AVCaptureMetadataOutput alloc] init];
     [self.output setMetadataObjectsDelegate:self queue:dispatch_get_main_queue()];
     [self.session addOutput:self.output];
 }
 
 - (void)setFormats:(NSArray *)formats {
-    if (formats.count == 0) {
-        self.output.metadataObjectTypes = self.output.availableMetadataObjectTypes;
-    } else {
-        NSMutableArray *allowedFormats = [[NSMutableArray alloc] initWithCapacity:formats.count];
-        for (NSString *format in formats) {
-            if ([format isEqualToString:@"upcA"]) {
-                [allowedFormats addObject:AVMetadataObjectTypeEAN13Code];
-            } else if ([format isEqualToString:@"upcE"]) {
-                [allowedFormats addObject:AVMetadataObjectTypeUPCECode];
-            } else if ([format isEqualToString:@"code39"]) {
-                [allowedFormats addObject:AVMetadataObjectTypeCode39Code];
-            } else if ([format isEqualToString:@"code39Mod43"]) {
-                [allowedFormats addObject:AVMetadataObjectTypeCode39Mod43Code];
-            } else if ([format isEqualToString:@"code93"]) {
-                [allowedFormats addObject:AVMetadataObjectTypeCode93Code];
-            } else if ([format isEqualToString:@"code128"]) {
-                [allowedFormats addObject:AVMetadataObjectTypeCode128Code];
-            } else if ([format isEqualToString:@"ean8"]) {
-                [allowedFormats addObject:AVMetadataObjectTypeEAN8Code];
-            } else if ([format isEqualToString:@"ean13"]) {
-                [allowedFormats addObject:AVMetadataObjectTypeEAN13Code];
-            } else if ([format isEqualToString:@"pdf417"]) {
-                [allowedFormats addObject:AVMetadataObjectTypePDF417Code];
-            } else if ([format isEqualToString:@"qr"]) {
-                [allowedFormats addObject:AVMetadataObjectTypeQRCode];
-            } else if ([format isEqualToString:@"aztec"]) {
-                [allowedFormats addObject:AVMetadataObjectTypeAztecCode];
-            } else if ([format isEqualToString:@"interleaved2of5"]) {
-                [allowedFormats addObject:AVMetadataObjectTypeInterleaved2of5Code];
-            } else if ([format isEqualToString:@"itf"]) {
-                [allowedFormats addObject:AVMetadataObjectTypeITF14Code];
-            } else if ([format isEqualToString:@"dataMatrix"]) {
-                [allowedFormats addObject:AVMetadataObjectTypeDataMatrixCode];
-            }
-        }
-        self.output.metadataObjectTypes = allowedFormats;
+    self.output.metadataObjectTypes = (formats.count == 0) ? self.output.availableMetadataObjectTypes : [self allowedFormatsFrom:formats];
+}
+
+- (NSArray<NSNumber *> *)allowedFormatsFrom:(NSArray *)formats {
+    NSMutableArray *allowedFormats = [NSMutableArray arrayWithCapacity:formats.count];
+    NSDictionary *formatMap = @{
+        @"upcA"            : AVMetadataObjectTypeEAN13Code,
+        @"upcE"            : AVMetadataObjectTypeUPCECode,
+        @"code39"          : AVMetadataObjectTypeCode39Code,
+        @"code39Mod43"     : AVMetadataObjectTypeCode39Mod43Code,
+        @"code93"          : AVMetadataObjectTypeCode93Code,
+        @"code128"         : AVMetadataObjectTypeCode128Code,
+        @"ean8"            : AVMetadataObjectTypeEAN8Code,
+        @"ean13"           : AVMetadataObjectTypeEAN13Code,
+        @"pdf417"          : AVMetadataObjectTypePDF417Code,
+        @"qr"              : AVMetadataObjectTypeQRCode,
+        @"aztec"           : AVMetadataObjectTypeAztecCode,
+        @"interleaved2of5" : AVMetadataObjectTypeInterleaved2of5Code,
+        @"itf"             : AVMetadataObjectTypeITF14Code,
+        @"dataMatrix"      : AVMetadataObjectTypeDataMatrixCode
+    };
+    for (NSString *format in formats) {
+        if (formatMap[format]) [allowedFormats addObject:formatMap[format]];
     }
+    return [allowedFormats copy];
 }
 
 - (AVCaptureDevice *)getCaptureDevice {
-    if ([self.camera isEqualToString:@"front"]) {
-        return [self frontCamera];
-    } else if ([self.camera isEqualToString:@"back"]) {
-        return [self rearCamera];
-    }
-    return [self rearCamera];
+    return ([self.camera isEqualToString:@"front"]) ? [self frontCamera] : [self rearCamera];
 }
 
-
 - (AVCaptureDevice *)frontCamera {
-    NSArray *devices = [AVCaptureDevice devicesWithMediaType:AVMediaTypeVideo];
-    for (AVCaptureDevice *device in devices) {
-        if ([device position] == AVCaptureDevicePositionFront) {
+    for (AVCaptureDevice *device in [AVCaptureDevice devicesWithMediaType:AVMediaTypeVideo]) {
+        if (device.position == AVCaptureDevicePositionFront) {
             return device;
         }
     }
@@ -198,36 +169,70 @@
 
 - (void)sendDetect:(NSString *)data format:(NSString *)format {
     if (self.detectListener && format && data) {
-        [self fireEventNamed:@"detect" withAttributes:@{@"format":format, @"data":data}];
+        [self fireEventNamed:@"detect" withAttributes:@{@"format": format, @"data": data}];
     }
 }
 
 - (void)sendError:(NSString *)error {
     if (self.errorListener) {
-        [self fireEventNamed:@"error" withAttributes:@{@"error":error ?: [NSNull null]}];
+        [self fireEventNamed:@"error" withAttributes:@{@"error": error ?: [NSNull null]}];
     }
 }
 
-#pragma mark - AVCaptureSessionRuntimeErrorNotification
-- (void)captureSessionRuntimeErrorNotification:(NSNotification*)notification {
-    NSError* error = [[notification.userInfo objectForKey:AVCaptureSessionErrorKey] objectAsInstanceOf:[NSError class]];
-    [self.context.asyncCodeDispatcher dispatch:^{
-        [self sendError:error.localizedDescription ?: error.description];
-    }];
+- (void)setResolution:(BSTabrisCameraResolution *)resolution {
+    AVCaptureDeviceFormat *format = [self captureFormatWithResolution:resolution];
+    if (!format) {
+        [NSException raise:ESBarcodeScannerExceptionName format:@"`AVCaptureDeviceFormat` with requested resolution (%@) not found.", resolution];
+    }
+    [self updateCaptureFormat:format];
+    _resolution = format.tabrisResolution;
 }
 
-#pragma mark - AVCaptureMetadataOutputObjectsDelegate methods
+- (BSTabrisCameraResolution *)resolution {
+    return _resolution ?: (_resolution = [self getCaptureDevice].activeFormat.tabrisResolution);
+}
+- (void)setFrameDuration:(NSNumber *)frameDuration {
+    AVCaptureDeviceFormat *format = [self captureFormatWithResolution:self.resolution frameDuration:frameDuration.doubleValue];
+    if (!format) {
+        [NSException raise:ESBarcodeScannerExceptionName format:@"`AVCaptureDeviceFormat` with requested resolution (%@) and frame rate (%f) not found.", self.resolution, frameDuration.doubleValue];
+    }
+    [self updateCaptureFormat:format frameDuration:frameDuration.doubleValue];
+    _frameDuration = frameDuration;
+}
+
+- (NSNumber *)frameDuration {
+    if (!_frameDuration) {
+        CMTime frameDuration = [self getCaptureDevice].activeVideoMinFrameDuration;
+        _frameDuration = @(frameDuration.timescale / frameDuration.value);
+    }
+    return _frameDuration;
+}
+
+- (NSArray<BSTabrisCameraResolution *> *)availableResolutions {
+    AVCaptureDevice *device = self.device ?: [self getCaptureDevice];
+    NSMutableSet *resolutionsSet = [NSMutableSet set];
+    for (AVCaptureDeviceFormat *format in device.formats) {
+        [resolutionsSet addObject:[BSCameraResolution withCaptureDeviceFormat:format]];
+    }
+    NSArray *sorted = [resolutionsSet.allObjects sortedArrayUsingSelector:@selector(compare:)];
+    return [self cameraResolutionsToTabrisArray:sorted];
+}
+
+- (NSArray<NSNumber *> *)availableFrameDurations {
+    return [self availableFrameDurationsForResolution:self.resolution];
+}
+
+- (void)captureSessionRuntimeErrorNotification:(NSNotification *)notification {
+    NSError *error = notification.userInfo[AVCaptureSessionErrorKey];
+    [self.context.asyncCodeDispatcher dispatch:^{ [self sendError:error.localizedDescription ?: error.description]; }];
+}
 
 - (void)captureOutput:(AVCaptureOutput *)captureOutput didOutputMetadataObjects:(NSArray *)metadataObjects fromConnection:(AVCaptureConnection *)connection {
     for (AVMetadataObject *metadata in metadataObjects) {
         if ([metadata isKindOfClass:[AVMetadataMachineReadableCodeObject class]]) {
             NSString *data = [(AVMetadataMachineReadableCodeObject *)metadata stringValue];
             NSString *format = metadata.type;
-            if (!data || !format) {
-                continue;
-            }
-
-            if (![format isEqualToString:self.lastFormat] || ![data isEqualToString:self.lastData] || [[NSDate date] timeIntervalSince1970] - self.lastSent > 1) {
+            if (data && format && (![format isEqualToString:self.lastFormat] || ![data isEqualToString:self.lastData] || [[NSDate date] timeIntervalSince1970] - self.lastSent > 1)) {
                 [self sendDetect:data format:format];
                 self.lastData = data;
                 self.lastFormat = format;
@@ -235,6 +240,122 @@
             }
         }
     }
+}
+
+#pragma mark - Private methods
+
+- (void)setupAndStartSessionWithProperties:(NSDictionary *)properties {
+    if (!self.session) [self initializeSession];
+    if (self.session) {
+        [self setFormats:properties[@"formats"]];
+        [self.scanner addSession:self.session];
+        [self.backgroundCodeDispatcher dispatch:^{
+            [self.session startRunning];
+            AVCaptureDeviceFormat *format = [self captureFormatWithResolution:self.resolution frameDuration:self.frameDuration.doubleValue];
+            [self updateCaptureFormat:format frameDuration:self.frameDuration.doubleValue];
+        }];
+    }
+}
+
+- (void)requestCameraAccessThenStartSessionWithProperties:(NSDictionary *)properties {
+    __weak __typeof(self) weakSelf = self;
+    [AVCaptureDevice requestAccessForMediaType:AVMediaTypeVideo completionHandler:^(BOOL granted) {
+        __strong __typeof(self) strongSelf = weakSelf;
+        if (granted) {
+            dispatch_async(dispatch_get_main_queue(), ^{ [strongSelf start:properties]; });
+        } else {
+            [strongSelf sendError:@"Camera permission not granted"];
+        }
+    }];
+}
+
+- (BSTabrisFrameDurationsForResolutions *)frameDurationsForResolutions {
+    BSTabrisFrameDurationsForResolutions *frameDurationsForResolutions = [NSMutableDictionary new];
+    AVCaptureDevice *device = [self getCaptureDevice];
+    for (AVCaptureDeviceFormat *format in device.formats) {
+        BSTabrisCameraResolution *cameraResolution = [BSCameraResolution withCaptureDeviceFormat:format].toTabrisDictionary;
+        if (!frameDurationsForResolutions[cameraResolution]) {
+            frameDurationsForResolutions[cameraResolution] = [self availableFrameDurationsForResolution:cameraResolution];
+        }
+    }
+    NSMutableArray *cameraResolutionsWithFrameDurations = [NSMutableArray array];
+    [frameDurationsForResolutions enumerateKeysAndObjectsUsingBlock:^(BSTabrisCameraResolution *key, NSArray<NSNumber *> *obj, BOOL *stop) {
+        NSMutableDictionary *merged = key.mutableCopy;
+        merged[@"frameDurations"] = obj;
+        [cameraResolutionsWithFrameDurations addObject:merged.copy];
+    }];
+    return cameraResolutionsWithFrameDurations.copy;
+}
+
+- (NSArray<NSNumber *> *)availableFrameDurationsForResolution:(BSTabrisCameraResolution *)resolution {
+    NSMutableArray<NSNumber *> *frameDurations = [NSMutableArray array];
+    AVCaptureDevice *device = self.device ?: [self getCaptureDevice];
+    for (AVCaptureDeviceFormat *format in device.formats) {
+        if ([format.tabrisResolution isEqualToDictionary:resolution]) {
+            for (AVFrameRateRange *range in format.videoSupportedFrameRateRanges) {
+                NSNumber *frameDuration = @(range.maxFrameRate);
+                if (![frameDurations containsObject:frameDuration]) [frameDurations addObject:frameDuration];
+            }
+        }
+    }
+    return frameDurations;
+}
+
+- (void)updateCaptureFormat:(AVCaptureDeviceFormat *)format {
+    NSError *error;
+    if ([self.device lockForConfiguration:&error]) {
+        self.device.activeFormat = format;
+        _frameDuration = nil;
+        [self.device unlockForConfiguration];
+    } else if (error) {
+        [NSException raise:ESBarcodeScannerExceptionName format:@"Error locking configuration: %@", error.localizedDescription];
+    }
+}
+
+- (void)updateCaptureFormat:(AVCaptureDeviceFormat *)format frameDuration:(CGFloat)frameDuration {
+    NSError *error;
+    if ([self.device lockForConfiguration:&error]) {
+        self.device.activeFormat = format;
+        self.device.activeVideoMinFrameDuration = CMTimeMake(1, frameDuration);
+        self.device.activeVideoMaxFrameDuration = CMTimeMake(1, frameDuration);
+        _frameDuration = nil;
+        [self.device unlockForConfiguration];
+    } else if (error) {
+        [NSException raise:ESBarcodeScannerExceptionName format:@"Error locking configuration: %@", error.localizedDescription];
+    }
+}
+
+- (AVCaptureDeviceFormat *)captureFormatWithResolution:(BSTabrisCameraResolution *)resolution {
+    AVCaptureDevice *device = self.device ?: [self getCaptureDevice];
+    for (AVCaptureDeviceFormat *format in device.formats) {
+        if ([format.tabrisResolution isEqualToDictionary:resolution]) {
+            return format;
+        }
+    }
+    return nil;
+}
+
+- (AVCaptureDeviceFormat *)captureFormatWithResolution:(BSTabrisCameraResolution *)resolution frameDuration:(CGFloat)frameDuration {
+    AVCaptureDevice *device = self.device ?: [self getCaptureDevice];
+    for (AVCaptureDeviceFormat *format in device.formats) {
+        if ([format.tabrisResolution isEqualToDictionary:resolution]) {
+            for (AVFrameRateRange *range in format.videoSupportedFrameRateRanges) {
+                if (range.minFrameRate <= frameDuration && range.maxFrameRate >= frameDuration) {
+                    return format;
+                }
+            }
+        }
+    }
+    return nil;
+}
+
+- (NSArray<BSTabrisCameraResolution *> *)cameraResolutionsToTabrisArray:(NSArray<BSCameraResolution *> *)cameraResolutions {
+    NSMutableArray<BSTabrisCameraResolution *> *tabrisArray = [NSMutableArray arrayWithCapacity:cameraResolutions.count];
+    for (BSCameraResolution *resolution in cameraResolutions) {
+        BSTabrisCameraResolution *tabrisResolution = resolution.toTabrisDictionary;
+        if (![tabrisArray containsObject:tabrisResolution]) [tabrisArray addObject:tabrisResolution];
+    }
+    return tabrisArray;
 }
 
 @end

--- a/www/BarcodeScannerView.js
+++ b/www/BarcodeScannerView.js
@@ -1,7 +1,6 @@
 const EVENT_TYPES = ['detect', 'error'];
 
 class BarcodeScannerView extends tabris.Widget {
-
   constructor(properties) {
     super(properties);
   }
@@ -30,11 +29,11 @@ class BarcodeScannerView extends tabris.Widget {
     super._dispose();
   }
 
-  start(formats) {
+  start(formats = []) {
     if (this.active) {
-      throw new Error('BarcodeScanner is already active')
+      throw new Error('BarcodeScanner is already active');
     }
-    this._nativeCall('start', {formats: formats || []});
+    this._nativeCall('start', { formats });
     this._storeProperty('active', true);
   }
 
@@ -42,24 +41,64 @@ class BarcodeScannerView extends tabris.Widget {
     this._nativeCall('stop');
     this._storeProperty('active', false);
   }
-
 }
 
 tabris.NativeObject.defineProperties(BarcodeScannerView.prototype, {
-  'camera': {
+  camera: {
     type: 'string',
     choice: ['front', 'back'],
     default: 'back'
   },
-  'scaleMode': {
+  scaleMode: {
     type: 'string',
     choice: ['fit', 'fill'],
     default: 'fit'
   },
-  'active': {
+  active: {
     type: 'boolean',
     readonly: true
-  },
+  }
 });
+
+if (device.platform === 'iOS') {
+  tabris.NativeObject.defineProperties(BarcodeScannerView.prototype, {
+
+    // `frameDurationsForResolutions` will change depending on the value of
+    // the `camera` property; otherwise, it's constant.
+
+    // Changing the `camera` property (front/back) will change
+    // `availableResolutions`!
+
+    // Setting an unsupported `resolution` or `frameDuration` value will
+    // result in an exception being thrown!
+
+    // Changing `resolution` will change `availableFrameDurations`!
+
+    // On iOS, different frameDurations are available for each resolution.
+    // When modifying the `resolution` property, the `frameDuration` will most
+    // likely change too!
+
+    frameDurationsForResolutions: {
+      type: 'any',
+      nocache: true,
+    },
+    resolution: {
+      type: 'any',
+      nocache: true,
+    },
+    availableResolutions: {
+      type: 'any',
+      nocache: true,
+    },
+    frameDuration: {
+      type: 'any',
+      nocache: true,
+    },
+    availableFrameDurations: {
+      type: 'any',
+      nocache: true,
+    },
+  });
+}
 
 module.exports = BarcodeScannerView;


### PR DESCRIPTION
This change was necessary to fix issues with barcode scanning under fluorescent lighting conditions in warehouses.

By enhancing the plugin API, developers can now choose camera resolutions and frame duration, which can adapt the barcode scanner's performance to different lighting conditions.

No side effects are expected as these changes are optional and only requested during specific configuration setups.